### PR TITLE
Fix symlinks for git annex

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -39,7 +39,18 @@ passed as optional argument.
 Meson subprojects are automatically ignored if ``meson.build`` exists in the
 project root. ``--include-meson-subprojects`` overrides this behaviour.
 
-Symbolic links and files that are zero-sized are automatically ignored.
+Files that are zero-sized are automatically ignored.
+
+Symbolic links are handled differently depending on the target of the link:
+
+#. a symlink pointing to a covered file is considered to be the same file as
+   the covered file and is therefore ignored.
+#. a symlink pointing to a file that is not a covered file is itself considered
+   to be a covered file and is not skipped, unless the symlink is ignored by
+   other means.
+
+A "covered file" is the term used in the REUSE Specification to name a file
+that needs copyright and licensing information.
 
 annotate
 ========

--- a/src/reuse/__init__.py
+++ b/src/reuse/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2021 Alliander N.V.
+# SPDX-FileCopyrightText: 2023 Matthias Riße
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,6 +26,8 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, NamedTuple, Optional, Set, Type
 
 from boolean.boolean import Expression
+
+import reuse.compat
 
 try:
     __version__ = version("reuse")

--- a/src/reuse/_util.py
+++ b/src/reuse/_util.py
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
 # SPDX-FileCopyrightText: 2023 DB Systel GmbH
 # SPDX-FileCopyrightText: 2023 Johannes Zarl-Zierl <johannes@zarl-zierl.at>
+# SPDX-FileCopyrightText: 2023 Matthias Riße
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -475,6 +476,10 @@ class PathType:
                 raise ArgumentTypeError(
                     _("'{}' is not a directory").format(path)
                 )
+            return
+        if not path.exists() and path.is_symlink():
+            # If the path is a broken symlink we can continue, allowing usage of
+            # --force-dot-license even if the link target is not readable.
             return
         raise ArgumentTypeError(_("can't open '{}'").format(path))
 

--- a/src/reuse/compat.py
+++ b/src/reuse/compat.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """This module adds compatibility code like backports."""
+import os
 import sys
+from pathlib import Path
 
 # Introduce an implementation of pathlib.Path's is_relative_to in python
 # versions before 3.9
 if sys.version_info < (3, 9):
-    from pathlib import Path
 
     def _is_relative_to(self: Path, path: Path) -> bool:
         try:
@@ -18,3 +19,12 @@ if sys.version_info < (3, 9):
             return False
 
     setattr(Path, "is_relative_to", _is_relative_to)
+
+# Introduce an implementation of pathlib.Path's readlink in python versions
+# before 3.9
+if sys.version_info < (3, 9):
+
+    def _readlink(self: Path) -> Path:
+        return Path(os.readlink(self))
+
+    setattr(Path, "readlink", _readlink)

--- a/src/reuse/compat.py
+++ b/src/reuse/compat.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2023 Matthias Riße
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""This module adds compatibility code like backports."""
+import sys
+
+# Introduce an implementation of pathlib.Path's is_relative_to in python
+# versions before 3.9
+if sys.version_info < (3, 9):
+    from pathlib import Path
+
+    def _is_relative_to(self: Path, path: Path) -> bool:
+        try:
+            self.relative_to(path)
+            return True
+        except ValueError:
+            return False
+
+    setattr(Path, "is_relative_to", _is_relative_to)

--- a/src/reuse/header.py
+++ b/src/reuse/header.py
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Yaman Qalieh
 # SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2023 Matthias Riße
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -392,7 +393,7 @@ def _is_uncommentable(path: Path) -> bool:
     registered as an UncommentableCommentStyle.
     """
     is_uncommentable = _get_comment_style(path) == UncommentableCommentStyle
-    return is_uncommentable or is_binary(str(path))
+    return is_uncommentable or path.is_symlink() or is_binary(str(path))
 
 
 def _verify_paths_line_handling(

--- a/src/reuse/report.py
+++ b/src/reuse/report.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Pietro Albini <pietro.albini@ferrous-systems.com>
+# SPDX-FileCopyrightText: 2023 Matthias Riße
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -445,14 +446,14 @@ class FileReport:
     ) -> "FileReport":
         """Generate a FileReport from a path in a Project."""
         path = Path(path)
-        if not path.is_file():
-            raise OSError(f"{path} is not a file")
+        if not path.is_file() and not path.is_symlink():
+            raise OSError(f"{path} is not supported")
 
         relative = project.relative_from_root(path)
         report = cls("./" + str(relative), path, do_checksum=do_checksum)
 
         # Checksum and ID
-        if report.do_checksum:
+        if report.do_checksum and not path.is_symlink():
             report.spdxfile.chk_sum = _checksum(path)
         else:
             # This path avoids a lot of heavy computation, which is handy for

--- a/src/reuse/vcs.py
+++ b/src/reuse/vcs.py
@@ -100,7 +100,7 @@ class VCSStrategyGit(VCSStrategy):
         ]
         result = execute_command(command, _LOGGER, cwd=self.project.root)
         all_files = result.stdout.decode("utf-8").split("\0")
-        return {Path(file_) for file_ in all_files[:-1]}
+        return {Path(file_) for file_ in all_files[:-1]}.union({Path(".git")})
 
     def is_ignored(self, path: StrPath) -> bool:
         path = self.project.relative_from_root(path)
@@ -168,7 +168,7 @@ class VCSStrategyHg(VCSStrategy):
         ]
         result = execute_command(command, _LOGGER, cwd=self.project.root)
         all_files = result.stdout.decode("utf-8").split("\0")
-        return {Path(file_) for file_ in all_files[:-1]}
+        return {Path(file_) for file_ in all_files[:-1]}.union({Path(".hg")})
 
     def is_ignored(self, path: StrPath) -> bool:
         path = self.project.relative_from_root(path)

--- a/src/reuse/vcs.py
+++ b/src/reuse/vcs.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: © 2020 Liferay, Inc. <https://liferay.com>
 # SPDX-FileCopyrightText: 2020 John Mulligan <jmulligan@redhat.com>
+# SPDX-FileCopyrightText: 2023 Matthias Riße
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -99,11 +100,15 @@ class VCSStrategyGit(VCSStrategy):
         ]
         result = execute_command(command, _LOGGER, cwd=self.project.root)
         all_files = result.stdout.decode("utf-8").split("\0")
-        return {Path(file_) for file_ in all_files}
+        return {Path(file_) for file_ in all_files[:-1]}
 
     def is_ignored(self, path: StrPath) -> bool:
         path = self.project.relative_from_root(path)
-        return path in self._all_ignored_files
+        return path in self._all_ignored_files or any(
+            path.is_relative_to(ignored_dir)  # type: ignore
+            for ignored_dir in self._all_ignored_files
+            if ignored_dir.is_dir()
+        )
 
     @classmethod
     def in_repo(cls, directory: StrPath) -> bool:
@@ -163,11 +168,15 @@ class VCSStrategyHg(VCSStrategy):
         ]
         result = execute_command(command, _LOGGER, cwd=self.project.root)
         all_files = result.stdout.decode("utf-8").split("\0")
-        return {Path(file_) for file_ in all_files}
+        return {Path(file_) for file_ in all_files[:-1]}
 
     def is_ignored(self, path: StrPath) -> bool:
         path = self.project.relative_from_root(path)
-        return path in self._all_ignored_files
+        return path in self._all_ignored_files or any(
+            path.is_relative_to(ignored_dir)  # type: ignore
+            for ignored_dir in self._all_ignored_files
+            if ignored_dir.is_dir()
+        )
 
     @classmethod
     def in_repo(cls, directory: StrPath) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Free Software Foundation Europe e.V. <https://fsfe.org>
 # SPDX-FileCopyrightText: 2022 Florian Snow <florian@familysnow.net>
 # SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2023 Matthias Riße
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -134,6 +135,15 @@ def fake_repository(tmpdir_factory) -> Path:
         "SPDX-License-Identifier: GPL-3.0-or-later\n"
         "SPDX-License-Identifier: Apache-2.0 OR CC0-1.0"
         " WITH Autoconf-exception-3.0\n",
+        encoding="utf-8",
+    )
+
+    (directory / "symlink-to-covered").symlink_to(directory / "doc/index.rst")
+    (directory / "symlink-to-not-covered").symlink_to(directory)
+    (directory / "symlink-to-not-covered.license").write_text(
+        "# SPDX-FileCopyrightText: 2017 Jane Doe\n"
+        "#\n"
+        "# SPDX-License-Identifier: GPL-3.0-or-later",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
This PR implements the heuristic for better handling of symlinks as described in https://github.com/fsfe/reuse-tool/issues/627#issuecomment-1422594763.

Basically, this is based on an interpretation of the REUSE specification that:
1. a symlink pointing to a covered file is considered to be the same
    file as the covered file and can therefore be ignored.
2. a symlink pointing to a file that is not a covered file is itself
    considered to be a covered file and should not be ignored, unless the
    symlink itself is ignored by other means.